### PR TITLE
download hq instead of lq + skip deleted posts + minor semantic changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,94 +7,64 @@ const promiseConcat = f => x => f().then(concat(x));
 const promiseReduce = (acc, x) => acc.then(promiseConcat(x));
 const serial = funcs => funcs.reduce(promiseReduce, Promise.resolve([]));
 
-// https://vine.co/api/users/profiles/vanity/${ username }
+// https://vine.co/api/users/profiles/vanity/${username}
 function getUserIdByUsername(username) {
   return new Promise(resolve => {
-    axios.get(`https://vine.co/api/users/profiles/vanity/${ username }`)
+    axios.get(`https://vine.co/api/users/profiles/vanity/${username}`)
       .then(response => {
         const data = response.data;
         const userId = data.data.userIdStr;
-
         resolve(userId);
-      })
+     })
       .catch(error => {
         console.error('Error while extracting user id from username', error);
-      });
-  });
+     });
+ });
 }
 
-// https://archive.vine.co/profiles/${ userId }.json
+// https://archive.vine.co/profiles/${userId}.json
 function getUserData(userId) {
   return new Promise(resolve => {
-    axios.get(`https://archive.vine.co/profiles/${ userId }.json`)
+    axios.get(`https://archive.vine.co/profiles/${userId}.json`)
       .then(response => {
-        //
         const data = response.data;
-        // const userId = json.data.userId;
-
         resolve(data);
-      })
+     })
       .catch(error => {
-        console.error(`Error while extracting user #${ userId } data`, error);
-      });
-  });
+        console.error(`Error while extracting user #${userId} data`, error);
+     });
+ });
 }
 
-// https://archive.vine.co/posts/${ postId }.json
+// https://archive.vine.co/posts/${postId}.json
 function getPostData(postId) {
+  let postMetadataURL = `https://archive.vine.co/posts/${postId}.json`
   return new Promise(resolve => {
-    axios.get(`https://archive.vine.co/posts/${ postId }.json`)
+    axios.get(postMetadataURL)
       .then(response => {
         const data = response.data;
-        // const userId = json.data.userId;
-
         resolve(data);
-      })
+     })
       .catch(error => {
-        console.error(`Error while extracting post #${ postId } data`, error);
-      });
-  });
+        console.error(`
+          Failed to fetch metadata for ${postMetadataURL}
+          Post is likely missing/deleted and will be skipped.
+        `);
+        resolve(null);
+     });
+ });
 }
 
+// Post Metadata: 2015/05/27, 08:48 | Description | loops: 43, likes: 0, reposts: 0, comments: 0, id: idInPermalink
 function getFilenameFromPostData(data) {
-  const date = new Date(data.created);
-  const [year, month, day] = [date.getFullYear(), date.getMonth(), date.getDate()];
-  const [hour, minutes] = [date.getHours(), date.getMinutes()];
+  let date = data.created.substring(0,10);
+  let description = data.description != '' ? data.description : 'null'
+  let videoID = data.permalinkUrl.substring(18)
 
-  // 2015/05/27, 08:48 | Description | loops: 43, likes: 0, reposts: 0, comments: 0, id: idInPermalink
-  let filename = `${ year }-${ month }-${ day }, ${ hour }-${ minutes }, `;
-
-  if (data.description) {
-    filename += data.description + ', ';
-  }
-
-  if (data.loops) {
-    filename += `loops ${ data.loops }, `;
-  }
-
-  if (data.likes) {
-    filename += `likes ${ data.likes }, `;
-  }
-
-  if (data.reposts) {
-    filename += `reposts ${ data.reposts }, `;
-  }
-
-  if (data.comments) {
-    filename += `comments ${ data.comments }, `;
-  }
-
-  filename += `id ${ new URL(data.permalinkUrl).pathname.split('/')[2] }`;
+  let filename = `${date} - ${description} - ${videoID}.mp4`
   filename = filename.replace(/[/\\?%*:|"<>]/g, '-');
-  filename += '.mp4';
 
   return filename;
-}
-
-const dirName = 'vine-archive';
-
-if (!fs.existsSync(dirName)){
-  fs.mkdirSync(dirName);
 }
 
 const username = process.argv[2];
@@ -105,6 +75,12 @@ if (!username) {
   process.exit();
 }
 
+const dirName = username;
+
+if (!fs.existsSync(dirName)){
+  fs.mkdirSync(dirName);
+}
+
 console.log('Getting user id from username...');
 const userId = await getUserIdByUsername(username);
 
@@ -112,22 +88,23 @@ console.log('Getting user data...');
 const userData = await getUserData(userId);
 
 console.log('Saving user data in user-data.json...');
-fs.writeFileSync(`./${ dirName }/user-data.json`, JSON.stringify(userData, null, 2));
+fs.writeFileSync(`./${dirName}/user-data.json`, JSON.stringify(userData, null, 2));
 
 console.log('Getting all posts data...');
-const posts = await Promise.all(userData.posts.map(postId => {
+let allPosts = await Promise.all(userData.posts.map(postId => {
   return getPostData(postId);
 }));
 
-console.log('Saving user data in posts-data.json...');
-fs.writeFileSync(`./${ dirName }/posts-data.json`, JSON.stringify(posts, null, 2));
+let posts = allPosts.filter(x => x !== null);
+
+console.log(`Saving user data in ${dirName}/posts-data.json...`);
+fs.writeFileSync(`./${dirName}/posts-data.json`, JSON.stringify(posts, null, 2));
 
 const promises = posts.map((post, index) => () => {
-  const filename = getFilenameFromPostData(post);
-  const url = post.videoLowURL; // for some reason videoURL sometimes has broken videos and low are always ok
+  let filename = getFilenameFromPostData(post);
+  let url = post.videoUrl;
 
-  console.log(`${ index + 1 }/${ posts.length } Downloads ${ filename } to ./${ dirName }...`);
-
+  console.log(`${index + 1}/${posts.length} Downloads ${filename} to ./${dirName}...`);
   return download(url, './' + dirName, { filename });
 });
 


### PR DESCRIPTION
Posts are now downloaded using videoUrl (mind the casing) instead of videoLowURL.
Some posts don't appear on a user's profile (assumed deleted/lost) but the post ID appears in the user data. The post itself, besides the ID has no other data though, which crashed the script in these cases.
Now such posts will be skipped and print a warning in the console.
Simplified filenames to **YYYY-MM-DD** - **DESCRIPTION** - VIDEOID.
Tidied up some syntax (because I'm annoying)

Thanks a lot for writing this!